### PR TITLE
COMM-602 Updated rabbitmq version validation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -78,7 +78,7 @@ class rabbitmq(
   validate_string($package_name)
   validate_string($package_provider)
   validate_bool($repos_ensure)
-  validate_re($version, '^\d+\.\d+\.\d+(-\d+)*$') # Allow 3 digits and optional -n postfix.
+  validate_re($version, '^\d+\.\d+\.\d+(-\d+)*(ubuntu\d+?(\.\d+)?)?$') # Allow 3 digits, plus optionally a postfix (possibly containing 'ubuntu' in the name, such as '3.8.2-0ubuntu1.3')
   # Validate config parameters.
   validate_re($cluster_node_type, '^(ram|disc|disk)$') # Both disc and disk are valid http://www.rabbitmq.com/clustering.html
   validate_array($cluster_nodes)


### PR DESCRIPTION
More recent Ubuntu versions of Rabbitmq have names like '3.8.2-0ubuntu1.4'.

```
root@ubuntu2004-2:/var/log/rabbitmq# apt list -a rabbitmq-server
Listing... Done
rabbitmq-server/focal-updates,now 3.8.2-0ubuntu1.4 all [installed]
rabbitmq-server/focal-security 3.8.2-0ubuntu1.3 all
rabbitmq-server/focal 3.8.2-0ubuntu1 all
```

The current validation does not allow to install these versions. I have tested the new regular expression with the following versions and they all match, so it should be perfectly backward compatible.

`3.8.2-0ubuntu1.4`
`3.8.2-0ubuntu1`
`3.8.2-0`
`3.8.2`

